### PR TITLE
Added se_light enum (off/on) for Sensibo Elements including migration.

### DIFF
--- a/.homeycompose/capabilities/se_light.json
+++ b/.homeycompose/capabilities/se_light.json
@@ -1,0 +1,27 @@
+{
+  "type": "enum",
+  "title": {
+    "en": "Light"
+  },
+  "desc": {
+    "en": "Light state"
+  },
+  "getable": true,
+  "setable": true,
+  "uiComponent": "picker",
+  "insights": false,
+  "values": [
+    {
+      "id": "off",
+      "title": {
+        "en": "Off"
+      }
+    },
+    {
+      "id": "on",
+      "title": {
+        "en": "On"
+      }
+    }
+  ]
+}

--- a/.homeycompose/flow/actions/sensibo_light.json
+++ b/.homeycompose/flow/actions/sensibo_light.json
@@ -14,7 +14,7 @@
     {
       "type": "device",
       "name": "device",
-      "filter": "driver_id=Sensibo|SensiboPure"
+      "filter": "driver_id=Sensibo|SensiboPure|SensiboElements"
     },
     {
       "name": "state",

--- a/.homeycompose/flow/actions/sensibo_light2.json
+++ b/.homeycompose/flow/actions/sensibo_light2.json
@@ -13,7 +13,7 @@
     {
       "type": "device",
       "name": "device",
-      "filter": "driver_id=Sensibo|SensiboPure"
+      "filter": "driver_id=Sensibo|SensiboPure|SensiboElements"
     },
     {
       "name": "state",

--- a/.homeycompose/flow/conditions/light_on.json
+++ b/.homeycompose/flow/conditions/light_on.json
@@ -7,7 +7,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=Sensibo|SensiboPure"
+      "filter": "driver_id=Sensibo|SensiboPure|SensiboElements"
     }
   ]
 }

--- a/app.json
+++ b/app.json
@@ -377,7 +377,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=Sensibo|SensiboPure"
+            "filter": "driver_id=Sensibo|SensiboPure|SensiboElements"
           }
         ]
       },
@@ -706,7 +706,7 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=Sensibo|SensiboPure"
+            "filter": "driver_id=Sensibo|SensiboPure|SensiboElements"
           },
           {
             "name": "state",
@@ -746,7 +746,7 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=Sensibo|SensiboPure"
+            "filter": "driver_id=Sensibo|SensiboPure|SensiboElements"
           },
           {
             "name": "state",
@@ -1352,6 +1352,7 @@
       },
       "class": "other",
       "capabilities": [
+        "se_light",
         "measure_temperature",
         "measure_humidity",
         "measure_co2",
@@ -1951,6 +1952,33 @@
       "setable": false,
       "uiComponent": null,
       "insights": false
+    },
+    "se_light": {
+      "type": "enum",
+      "title": {
+        "en": "Light"
+      },
+      "desc": {
+        "en": "Light state"
+      },
+      "getable": true,
+      "setable": true,
+      "uiComponent": "picker",
+      "insights": false,
+      "values": [
+        {
+          "id": "off",
+          "title": {
+            "en": "Off"
+          }
+        },
+        {
+          "id": "on",
+          "title": {
+            "en": "On"
+          }
+        }
+      ]
     },
     "se_onoff": {
       "type": "boolean",

--- a/drivers/BaseDevice.js
+++ b/drivers/BaseDevice.js
@@ -169,6 +169,7 @@ module.exports = class BaseDevice extends Homey.Device {
         if (thermostat_mode) {
           await this.updateIfChanged('thermostat_mode', thermostat_mode);
         }
+        await this.updateLightCapabilities(result.acState.light);
       }
       if (result.timer && result.timer.isEnabled && result.timer.targetTimeSecondsFromNow >= 0) {
         this.scheduleTimer(result.timer.targetTimeSecondsFromNow);
@@ -509,12 +510,25 @@ module.exports = class BaseDevice extends Homey.Device {
   }
 
   async isLightOn() {
+    const light = this._sensibo.getAcState()['light'];
+    if (light !== undefined) {
+      return light !== 'off';
+    }
     const lightModes = this._sensibo.getAllLights();
     if (lightModes) {
-      const light = this._sensibo.getAcState()['light'];
-      return !!light && light !== 'off';
+      return false;
     }
     throw new Error(this.homey.__('errors.light_not_supported'));
+  }
+
+  async updateLightCapabilities(lightState) {
+    if (lightState === undefined) {
+      return;
+    }
+    const normalizedLightState = lightState === 'off' ? 'off' : 'on';
+    if (this.hasCapability('se_light')) {
+      await this.updateIfChanged('se_light', normalizedLightState);
+    }
   }
 
   async onDeleteTimer() {
@@ -574,9 +588,18 @@ module.exports = class BaseDevice extends Homey.Device {
   async onControlLight(state) {
     try {
       this.clearCheckData();
-      this.log(`set light: ${this._sensibo.getDeviceId()} -> ${state}`);
-      await this._sensibo.setAcState({ light: state });
-      this.log(`set light OK: ${this._sensibo.getDeviceId()} -> ${state}`);
+      const normalizedState = String(state).toLowerCase();
+      if (normalizedState !== 'off' && normalizedState !== 'on') {
+        throw new Error(`Unsupported light state: ${normalizedState}`);
+      }
+      this.log(`set light: ${this._sensibo.getDeviceId()} -> ${normalizedState}`);
+      const lightModes = this._sensibo.getAllLights() || ['on', 'off'];
+      if (!lightModes.includes(normalizedState)) {
+        throw new Error(`Unsupported light state: ${normalizedState} (${lightModes.join(',')})`);
+      }
+      await this._sensibo.setAcProperty('light', normalizedState);
+      await this.updateLightCapabilities(normalizedState);
+      this.log(`set light OK: ${this._sensibo.getDeviceId()} -> ${normalizedState}`);
     } catch (err) {
       let message = err;
       if (err.response.data.message !== undefined) {
@@ -590,7 +613,7 @@ module.exports = class BaseDevice extends Homey.Device {
   }
 
   async onLightAutocomplete(query, args) {
-    const items = this._sensibo.getAllLights() || ['on', 'off'];
+    const items = ['off', 'on'];
     return Promise.resolve(
       items
         .map((item) => {

--- a/drivers/SensiboElements/device.js
+++ b/drivers/SensiboElements/device.js
@@ -4,6 +4,25 @@ const BaseDevice = require('../BaseDevice');
 
 module.exports = class SensiboElementsDevice extends BaseDevice {
 
+	async migrate() {
+		try {
+			if (!this.hasCapability('se_light')) {
+				await this.addCapability('se_light');
+			}
+			this.log('Migration OK');
+		} catch (err) {
+			this.log('Migration failed', err);
+		}
+	}
+
+	async registerCapabilityListeners() {
+		if (this.hasCapability('se_light')) {
+			this.registerCapabilityListener('se_light', async (value) => {
+				await this.onControlLight(value);
+			});
+		}
+	}
+
 	deviceName = () => 'SensiboElementsDevice';
 
 };

--- a/drivers/SensiboElements/driver.compose.json
+++ b/drivers/SensiboElements/driver.compose.json
@@ -8,6 +8,7 @@
 	],
 	"class": "other",
 	"capabilities": [
+		"se_light",
 		"measure_temperature",
 		"measure_humidity",
 		"measure_co2",


### PR DESCRIPTION
onControlLight is in BaseDevice, so strict off/on now affects Sensibo and Sensibo Pure too.

Seems that for light control, both Sensibo and SensiboPure support at least on/off in this app (and some models also report dim via API capabilities) but I can't verify this.

Light on/off tested and works for me fine on Sensibo Elements